### PR TITLE
Remove @aliases entry

### DIFF
--- a/R/margins.R
+++ b/R/margins.R
@@ -1,6 +1,5 @@
 #' @rdname margins
 #' @name margins
-#' @aliases margins-package
 #' @docType package
 #' @title Marginal Effects Estimation
 #' @description This package is an R port of Stata's \samp{margins} command, implemented as an S3 generic \code{margins()} for model objects, like those of class \dQuote{lm} and \dQuote{glm}. \code{margins()} is an S3 generic function for building a \dQuote{margins} object from a model object. Methods are currently implemented for several model classes (see Details, below).


### PR DESCRIPTION
Follow-up to https://github.com/r-lib/roxygen2/issues/1491#issuecomment-2261296140.

I would guess `@aliases` is being word-split so it's equivalent to `@aliases margins -package`. And then `\alias{margins-package}` is being added automatically from the `@docType package` entry. Not at a machine where I can test this worked ATM, sorry :)